### PR TITLE
refactor: optimize PDF text extraction to remove duplicate texts

### DIFF
--- a/backend/app/utils/pdf_processor.py
+++ b/backend/app/utils/pdf_processor.py
@@ -1,31 +1,53 @@
+import re
 import fitz
 from langchain_text_splitters import TokenTextSplitter
+import tiktoken
 
 
 def pdf_process_to_chunks(
-    file_bytes: bytes, file_hash: str, chunk_size: int = 1000, chunk_overlap: int = 100
+    file_bytes: bytes, file_hash: str, chunk_size: int = 512, chunk_overlap: int = 64
 ) -> list[dict]:
-    """
-    1. Opens the PDF from bytes using PyMuPDF.
-    2. Extracts text page-by-page to keep track of page numbers.
-    3. Uses RecursiveCharacterTextSplitter to break text into chunks.
-    4. Returns a list of dictionaries containing text, hash, and page_label.
-    """
+
     doc = fitz.open(stream=file_bytes, filetype="pdf")
+    encoding = tiktoken.get_encoding("cl100k_base")
 
     splitter = TokenTextSplitter(
-        chunk_size=512,  
-        chunk_overlap=64,  
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
         encoding_name="cl100k_base",
     )
 
     final_chunks = []
+    # this set will track content across the WHOLE document
+    global_seen_content = set()
 
     for page_num, page in enumerate(doc):
-        page_text = page.get_text("text")
+        raw_text = page.get_text("text")
+        raw_token_count = len(encoding.encode(raw_text))
 
-        chunks = splitter.split_text(page_text)
+        # split page into lines/paragraphs
+        lines = raw_text.split("\n")
+        unique_page_lines = []
 
+        for line in lines:
+            if not line:
+                continue
+
+            # create a 'fingerprint' by removing all spaces
+            fingerprint = re.sub(r"\s+", "", line).lower()
+
+            # global Filter
+            if fingerprint not in global_seen_content:
+                unique_page_lines.append(line)
+                global_seen_content.add(fingerprint)
+
+        clean_text = " ".join(unique_page_lines)
+
+        # one last pass to ensure no weird unicode characters remain
+        clean_text = re.sub(r"\s+", " ", clean_text).strip()
+
+        # split and store
+        chunks = splitter.split_text(clean_text)
         for chunk in chunks:
             final_chunks.append(
                 {


### PR DESCRIPTION
# Problem
Standard extraction was picking up redundant OCR layer. Meaning sections of texts are repeated multiple times. This was causing us to 3-4x more tokens than necessary. This eats up tokens, and would eventually make queries slower since there is a lot of duplicates

# Solution
Use a set to prevent duplicates of texts from being counted as chunks

![Uploading image.png…]()
