### PR TITLE
fixed bad merge in docker-compose.yaml and syntax issue.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,10 @@ services:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       NOMIC_API_KEY: ${NOMIC_API_KEY} 
       PYTHONUNBUFFERED: 1
-<<<<<<< fix/deploying-port-issue
       PORT: ${PORT}
-=======
-      MAX_PDF_PAGES: ${MAX_PDF_PAGES:1100}
-      MAX_DOCUMENT_TOKENS: ${MAX_DOCUMENT_TOKENS:55000}
->>>>>>> main
+      MAX_PDF_PAGES: ${MAX_PDF_PAGES:-1100}
+      MAX_DOCUMENT_TOKENS: ${MAX_DOCUMENT_TOKENS:-55000}
+
 
   #frontend:
   #    build:


### PR DESCRIPTION
after merge somehow the merge dialogue characters got left in the file. Also default values in docker should be denoted by "-"