### PR TITLE
fix: disable score filtering and user_id document chunk metadata filt…

### DIFF
--- a/backend/app/services/assessment_service.py
+++ b/backend/app/services/assessment_service.py
@@ -223,7 +223,6 @@ class AssessmentService:
         filters = {
             "$and": [
                 {"document_id": {"$in": document_ids}},
-                {"user_id": {"$eq": user_id}},
             ]
         }
 
@@ -240,10 +239,9 @@ class AssessmentService:
             distance = item[1]
             similarity = 1 - distance
 
-            if similarity > 0.60:  # keep only 60% or better matches
-                valid_chunks.append(
-                    {"id": item[0], "score": similarity, "metadata": item[2]}
-                )
+            valid_chunks.append(
+                {"id": item[0], "score": similarity, "metadata": item[2]}
+            )
 
         valid_chunks.sort(key=lambda x: x["score"], reverse=True)
 


### PR DESCRIPTION
by disabling score filtering we fix the problems of assessments generating because maybe no document chunks don't meet the score threshold, if the user puts a minimal query or topic

removing the user_id document chun metadata filtering allows multiple users to upload the same document and still be able to generate exams from that. there is a user_id field in the document_chunks table that is no longer valid because users can share a document, and so chunks don't belong to a particular user, but to a document solely