### PR TITLE
perf: optimize assessment loading and fix pending status lag

### DIFF
--- a/backend/app/services/assessment_service.py
+++ b/backend/app/services/assessment_service.py
@@ -319,7 +319,7 @@ class AssessmentService:
         difficulty: str,
     ):
         """
-        MANAGER: Orchestrates the entire background task.
+        MANAGER: Orchestrates the task of generating an assessment
         """
         try:
             # update status to processing
@@ -377,13 +377,24 @@ class AssessmentService:
         assessments = []
 
         for row in response.data:
+            # Handle source files (can be single document_id or list document_ids)
+            source_files = []
+            if row.get("document_id"):
+                source_files.append(row["document_id"])
+            if row.get("document_ids"):
+                source_files.extend(row["document_ids"])
+
+            # Ensure unique IDs and convert to list if it was a set
+            unique_source_files = list(set(source_files))
+
             assessments.append(
                 {
                     "id": row.get("id"),
                     "title": row.get("title"),  # Rename for frontend
+                    "topic": row.get("query") or "",  # Frontend expects topic
                     "createdAt": row.get("created_at"),
                     "status": row.get("status"),
-                    "sourceFiles": row.get("document_id"),  # Standardize key
+                    "sourceFiles": unique_source_files,  # Return list of IDs
                     "questionCount": row.get("num_questions"),
                     "difficulty": row.get("difficulty"),  # Rename for frontend
                     # TODO add attempts when added to db

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -12,6 +12,7 @@ interface AppContextType {
   assessments: Assessment[];
   setAssessments: (assessments: Assessment[]) => void;
   fetchAssessments: () => Promise<void>;
+  fetchAssessmentDetails: (assessmentId: string) => Promise<Assessment | null>;
   currentAssessment: Assessment | null;
   setCurrentAssessment: (assessment: Assessment | null) => void;
   activities: Activity[];
@@ -103,32 +104,17 @@ export function AppProvider({ children }: { children: ReactNode }) {
       const assessments: Assessment[] = data.map((ass: any) => ({
         id: ass.id,
         title: ass.title,
-        topic: ass.topic || '', // !!! backend should return this maybe
+        topic: ass.topic || '',
         createdAt: new Date(ass.createdAt),
-        status: ass.status as 'completed' | 'pending' | 'failed',
-        sourceFiles: [ass.sourceFiles], // !!! Backend returns single document_id; wrap in array for now
+        status: ass.status as 'completed' | 'processing' | 'pending' | 'failed',
+        sourceFiles: ass.sourceFiles || [],
         questionCount: ass.questionCount,
         difficulty: ass.difficulty as 'easy' | 'medium' | 'hard' | 'none',
-        questions: [], // !!! Not provided by get assessments endpoint; initialize empty
-        bestScore: undefined, // !!! Not provided; set later if needed
-        lastScore: undefined, // !!! Not provided; set later if needed
-        attempts: { attempts: [], scores: [] }, // !!! Default empty
+        questions: [], // Initialize empty; fetch details when needed
+        bestScore: undefined,
+        lastScore: undefined,
+        attempts: { attempts: [], scores: [] },
       })).sort((a: Assessment, b: Assessment) => b.createdAt.getTime() - a.createdAt.getTime());
-
-      // Fetch questions
-      for (const ass of assessments) {
-        const questions = await get(`api/v1/assessments/${ass.id}`, session.access_token);
-        ass.questions = questions.map((que: any) => ({
-          id: que.id,
-          type: que.type,
-          question: que.question,
-          numOptions: que.options.length, // !!! consider removing?
-          options: que.options,
-          correctAnswer: que.correctAnswer,
-          userAnswer: que.userAnswer,
-          source: que.source,
-        }));
-      }
 
       setAssessments(assessments);
 
@@ -136,10 +122,44 @@ export function AppProvider({ children }: { children: ReactNode }) {
       if (assessments.some(ass => ass.status !== 'completed' && ass.status !== 'failed')) {
         setTimeout(() => {
           fetchAssessments();
-        }, 10000); // wait 10 seconds
+        }, 5000); // Polling more frequently (5s instead of 10s)
       }
     } catch (err) {
       console.error('error loading assessments', err);
+    }
+  };
+
+  const fetchAssessmentDetails = async (assessmentId: string): Promise<Assessment | null> => {
+    try {
+      const { data: { session } } = await supabaseClient.auth.getSession();
+      if (!session?.access_token) return null;
+
+      const questionsData = await get(`api/v1/assessments/${assessmentId}`, session.access_token);
+      const questions = questionsData.map((que: any) => ({
+        id: que.id,
+        type: que.type,
+        question: que.question,
+        numOptions: que.options ? que.options.length : 0,
+        options: que.options,
+        correctAnswer: que.correctAnswer,
+        userAnswer: que.userAnswer,
+        source: que.source,
+      }));
+
+      let updatedAssessment: Assessment | null = null;
+
+      setAssessments(prev => prev.map(ass => {
+        if (ass.id === assessmentId) {
+          updatedAssessment = { ...ass, questions };
+          return updatedAssessment;
+        }
+        return ass;
+      }));
+
+      return updatedAssessment;
+    } catch (err) {
+      console.error('error loading assessment details', err);
+      return null;
     }
   };
 
@@ -154,6 +174,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
         assessments,
         setAssessments,
         fetchAssessments,
+        fetchAssessmentDetails,
         currentAssessment,
         setCurrentAssessment,
         activities,

--- a/src/components/AssessmentsHub.tsx
+++ b/src/components/AssessmentsHub.tsx
@@ -7,17 +7,22 @@ import { useNavigate } from 'react-router-dom';
 const VITE_API_URL = import.meta.env.VITE_API_URL;
 
 export default function AssessmentsHub() {
-  const { assessments, setAssessments, setCurrentAssessment } = useApp();
+  const { assessments, setAssessments, setCurrentAssessment, fetchAssessmentDetails } = useApp();
   const [showDownloadMenu, setShowDownloadMenu] = useState<string | null>(null);
   const [showOptionsMenu, setShowOptionsMenu] = useState<string | null>(null);
   const [assessmentsFilter, setAssessmentsFilter] = useState<string | null>(null);
   const navigate = useNavigate();
 
-  const handleStartExam = (assessmentId: string) => {
-    const assessment = assessments.find(a => a.id === assessmentId);
-    if (assessment) {
-      setCurrentAssessment(assessment);
-      navigate('/dashboard/exam-mode');
+  const handleStartExam = async (assessmentId: string) => {
+    try {
+      const updatedAssessment = await fetchAssessmentDetails(assessmentId);
+      if (updatedAssessment) {
+        setCurrentAssessment(updatedAssessment);
+        navigate('/dashboard/exam-mode');
+      }
+    } catch (error) {
+      console.error('Failed to start exam:', error);
+      alert('Could not load assessment details. Please try again.');
     }
   };
 
@@ -186,10 +191,18 @@ export default function AssessmentsHub() {
               )}
                   
                 <button
-                onClick={() => {
+                onClick={async () => {
                   if (assessment.status === "completed") {
-                    setCurrentAssessment(assessment);
-                    navigate('/dashboard/grading-report');
+                    try {
+                      const updatedAssessment = await fetchAssessmentDetails(assessment.id);
+                      if (updatedAssessment) {
+                        setCurrentAssessment(updatedAssessment);
+                        navigate('/dashboard/grading-report');
+                      }
+                    } catch (error) {
+                      console.error('Failed to view results:', error);
+                      alert('Could not load assessment results. Please try again.');
+                    }
                   }
                   }}
                   className={"w-full flex items-center justify-center gap-2 " + ((assessment.status === "completed") ? "bg-blue-100 hover:bg-blue-200 text-blue-600" : "bg-gray-200 text-gray-600 cursor-default") + " py-3 rounded-xl font-semibold"}

--- a/src/components/CreationStudio.tsx
+++ b/src/components/CreationStudio.tsx
@@ -68,33 +68,13 @@ export default function CreationStudio() {
         return;
       }
 
-      const res = await post(
+      await post(
         "api/v1/assessments",
         requestBody,
         session.access_token,
       );
 
-      const assessmentId = await res;
-
-      const newAssessment: Assessment = {
-        id: assessmentId,
-        topic: topic,
-        title: `Assessment: ${topic}`,
-        createdAt: new Date(),
-        status: "pending", // or 'processing'
-        sourceFiles: selectedFiles,
-        questionCount,
-        difficulty,
-        questions: [],
-        attempts: {
-          attempts: [],
-          scores: [],
-        },
-      };
-
-      setAssessments([newAssessment, ...assessments]);
-
-      fetchAssessments(); // will poll until assessment finishes processing (completes or fails)
+      await fetchAssessments();
 
       // Navigate to assessments hub where you can poll for status
       navigate("/dashboard/assessments");


### PR DESCRIPTION
Optimized the assessment loading workflow to improve initial startup performance and resolve a UI synchronization issue where a newly created assessment incorrectly appeared as "pending" when they were ready.

- Optimized Initial Load: Removed the loop in AppContext.tsx that fetched detailed questions for every assessment on startup. The
     fetchAssessments call now only retrieves metadata.
 - On-Demand Fetching: Added fetchAssessmentDetails to AppContext to fetch questions only when required (e.g., when a user clicks "Start
   Online" or "View Results").
 - Improved UI Responsiveness: Updated AssessmentsHub.tsx to utilize on-demand fetching, making the initial dashboard load nearly
   instantaneous.
 - Cleanup: Removed manual "pending" state insertion in CreationStudio.tsx, relying on the awaited backend response and optimized polling
   for more accurate status tracking.
   
  Notes: We could use a loading screen when we click View Results or Start Online