### PR TITLE
fix: rename activity endpoint to prevent browser blocking

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,5 +1,12 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import documents, user, dev, assessments, notifications, activity
+from app.api.v1.endpoints import (
+    documents,
+    user,
+    dev,
+    assessments,
+    notifications,
+    activity,
+)
 
 api_router = APIRouter()
 
@@ -31,6 +38,6 @@ api_router.include_router(
 
 api_router.include_router(
     activity.router,
-    prefix="/activity",
-    tags=["Activity"]
+    prefix="/recent-activity",  # avoids the blocked "activity" keyword
+    tags=["Activity"],
 )

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -102,7 +102,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
       }
 
       //fetch the recent activity
-      const data = await get('api/v1/activity', session.access_token);
+      const data = await get('api/v1/recent-activity', session.access_token);
       const activity: Activity[] = data.map((act: any) => ({
         id: act.id,
         type: act.type,


### PR DESCRIPTION
My browser Arc blocked this endpoint for some reason, maybe for ad-blocking reasons, but it prevented the Recent Activity from populating.