### PR TITLE
fix: question navigation buttons overflow off-screen on large assessments 

### DIFF
--- a/src/components/ExamMode.tsx
+++ b/src/components/ExamMode.tsx
@@ -296,11 +296,11 @@ export default function ExamMode() {
       </div>
 
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-lg">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center gap-4">
           <button
             onClick={handlePrevious}
             disabled={currentQuestion === 0}
-            className={`flex items-center gap-2 px-6 py-3 rounded-xl font-semibold transition-colors ${
+            className={`flex-shrink-0 flex items-center gap-2 px-6 py-3 rounded-xl font-semibold transition-colors ${
               currentQuestion === 0
                 ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
                 : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
@@ -310,29 +310,31 @@ export default function ExamMode() {
             Previous
           </button>
 
-          <div className="flex gap-2">
-            {questions.map((_, idx) => (
-              <button
-                key={idx}
-                onClick={() => setCurrentQuestion(idx)}
-                className={`w-8 h-8 rounded-lg font-semibold text-sm transition-all ${
-                  idx === currentQuestion
-                    ? 'bg-emerald-600 text-white'
-                    : answers[questions[idx].id] !== undefined
-                    ? 'bg-emerald-100 text-emerald-700'
-                    : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
-                }`}
-              >
-                {idx + 1}
-              </button>
-            ))}
+          <div className="flex-1 min-w-0 overflow-x-auto scrollbar-thin pb-4">
+            <div className="flex gap-2 w-max mx-auto">
+              {questions.map((_, idx) => (
+                <button
+                  key={idx}
+                  onClick={() => setCurrentQuestion(idx)}
+                  className={`w-8 h-8 rounded-lg font-semibold text-sm transition-all flex-shrink-0 ${
+                    idx === currentQuestion
+                      ? 'bg-emerald-600 text-white'
+                      : answers[questions[idx].id] !== undefined
+                      ? 'bg-emerald-100 text-emerald-700'
+                      : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
+                  }`}
+                >
+                  {idx + 1}
+                </button>
+              ))}
+            </div>
           </div>
 
           {isLastQuestion ? (
             <button
               onClick={handleSubmit}
               disabled={isSubmitting}
-              className="flex items-center gap-2 px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-shrink-0 flex items-center gap-2 px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isSubmitting ? 'Submitting...' : 'Submit'}
               <ChevronRight className="w-5 h-5" />
@@ -340,7 +342,7 @@ export default function ExamMode() {
           ) : (
             <button
               onClick={handleNext}
-              className="flex items-center gap-2 px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl font-semibold transition-colors"
+              className="flex-shrink-0 flex items-center gap-2 px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white rounded-xl font-semibold transition-colors"
             >
               Next
               <ChevronRight className="w-5 h-5" />

--- a/src/index.css
+++ b/src/index.css
@@ -16,4 +16,19 @@
   input[type='range']::-moz-range-thumb {
     @apply w-5 h-5 bg-emerald-600 rounded-full cursor-pointer border-0;
   }
+
+  .scrollbar-thin {
+    scrollbar-width: thin;
+    scrollbar-color: #d1d5db transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar {
+    height: 4px;
+  }
+  .scrollbar-thin::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    background-color: #d1d5db;
+    border-radius: 2px;
+  }
 }


### PR DESCRIPTION
# Problem 
When an assessment has large enough number of questions, the numbered question buttons in the bottom navigation bar overflow horizontally past the viewport. This pushes the Next/Submit button completely off-screen, making it impossible to navigate forward or submit the exam.

# Root Cause 
The question buttons were rendered in an unconstrained flex row with justify-between. Each button is 32px + 8px gap = 40px, so 50 questions = 2000px — far wider than any screen.

# Solution
- Wrapped the question buttons in a scrollable container (overflow-x-auto) that flexes to fill only the space between Previous and Next/Submit
- Added flex-shrink-0 to Previous and Next/Submit buttons so they always remain visible
- Added a subtle thin scrollbar style (4px height) so users can see there are more buttons to scroll to

# Files Changed

-  src/components/ExamMode.tsx — Constrained question nav area with flex-1 min-w-0 overflow-x-auto
-  src/index.css — Added .scrollbar-thin utility for a minimal scrollbar appearance
-  Testing Verified with 15, 32, and 50 question assessments. Previous and Next/Submit buttons remain visible in all cases.
-  Question buttons scroll horizontally when they exceed the available space.

Closes #183